### PR TITLE
Added Java type Config Object to get chart URL instead of providing non-formatted json string

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -9,6 +9,7 @@
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
@@ -22,6 +23,7 @@
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
@@ -32,6 +34,23 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .settings
 target/
+
+.project
+settings.json
+.classpath

--- a/README.md
+++ b/README.md
@@ -57,6 +57,39 @@ System.out.println(qc.getUrl());
 // https://quickchart.io/chart?c=%7B%22chart%22%3A+%7B%22type%22%3A+%22bar%22%2C+%22data%22%3A+%7B%22labels%22%3A+%5B%22Hello+world%22%2C+%22Test%22%5D%2C+%22datasets%22%3A+%5B%7B%22label%22%3A+%22Foo%22%2C+%22data%22%3A+%5B1%2C+2%5D%7D%5D%7D%7D%7D&w=600&h=300&bkg=%23ffffff&devicePixelRatio=2.0&f=png
 ```
 
+If you want to provide your Chart.js config in a neat manner instead of doing all the string formatting, you can use `getUrlV2()`
+
+Example:
+```java
+// Instanciate ChartConfig object
+ChartConfig config = new ChartConfig();
+
+// Set the char type. e.g bar, line etc
+config.setType("bar");
+//Instantiate ChartData
+ChartData data = new ChartData();
+// Set the labels and chart Data
+data.setLabels(List.of("Q1", "Q2", "Q3", "Q4"));  //labels
+
+//Dataset 1
+Dataset dataset = new Dataset();
+dataset.setLabel("Users");
+dataset.setData(List.of("50", "60", "70", "180"));
+
+//Dataset 2
+Dataset dataset2 = new Dataset();
+dataset2.setLabel("Revenue");
+dataset2.setData(List.of("100", "200", "300", "400"));
+
+//Set the required Data
+data.setDatasets(List.of(dataset, dataset2));
+config.setData(data);
+chart.setChartConfig(config);
+
+//get the URL
+chart.getUrlV2()
+
+```
 If you have a long or complicated chart, use `getShortUrl()` to get a fixed-length URL using the quickchart.io web service (note that these URLs only persist for a short time unless you have a subscription):
 
 ```java
@@ -79,6 +112,9 @@ You can set the following properties:
 ### setConfig(String)
 The Chart.js chart configuration.
 
+### setChartConfig(Object)
+The Chart.js config in terms of Java Object
+
 ### setWidth(Integer)
 Width of the chart image in pixels.  Defaults to 500
 
@@ -96,7 +132,6 @@ The Chart.js version of the chart.  See [QuickChart documentation](https://quick
 
 ### setKey(String)
 API key (not required)
-
 ---
 
 ## Creating chart URLs

--- a/pom.xml
+++ b/pom.xml
@@ -128,5 +128,11 @@
 			<artifactId>httpclient</artifactId>
 			<version>4.5.13</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.9</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/io/quickchart/QuickChart.java
+++ b/src/main/java/io/quickchart/QuickChart.java
@@ -9,6 +9,9 @@ import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 
+import io.quickchart.util.ChartUtils;
+import io.quickchart.vo.ChartConfig;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -35,6 +38,7 @@ public class QuickChart {
 	private String host;
 	private Integer port;
 
+	private ChartConfig chartConfig;
 	/**
 	 * Create a default QuickChart object.
 	 */
@@ -185,6 +189,26 @@ public class QuickChart {
 		this.config = config;
 	}
 
+
+	/**
+	 * Get the Chart.js config
+	 *
+	 * @return Chart.js config
+	 */
+	public ChartConfig getChartConfig() {
+		return chartConfig;
+	}
+
+	/**
+	 * Set the Chart.js chartConfig to render
+	 *
+	 * @param chartConfig Chart.js config. But in terms of ChartConfig object
+	 * 			 instead of JSON string.
+	 */
+	public void setChartConfig(ChartConfig chartConfig) {
+		this.chartConfig = chartConfig;
+	}
+
 	/**
 	 * Generate a URL that displays a chart
 	 *
@@ -211,6 +235,37 @@ public class QuickChart {
 		if (this.version != null && !this.version.isEmpty()) {
 			builder.addParameter("v", this.version);
 		}
+		return builder.toString();
+	}
+
+	/**
+	 * Generate a URL that displays a chart but takes ChartConfig object as input
+	 * instead of chart string
+	 *
+	 * @return URL that will display chart when rendered
+	 */
+	public String getUrlV2(){
+		URIBuilder builder = new URIBuilder();
+		builder.setScheme(this.scheme);
+		builder.setHost(this.host);
+		if (port != 80 && port != 443) {
+			builder.setPort(this.port);
+		}
+		builder.setPath("/chart");
+		builder.addParameter("w", this.width.toString());
+		builder.addParameter("h", this.height.toString());
+		builder.addParameter("devicePixelRatio", this.devicePixelRatio.toString());
+		if (!this.backgroundColor.equals("transparent")) {
+			builder.addParameter("bkg", this.backgroundColor);
+		}
+		builder.addParameter("c", ChartUtils.getChartConfigJSON(this.getChartConfig()));
+		if (this.key != null && !this.key.isEmpty()) {
+			builder.addParameter("key", this.key);
+		}
+		if (this.version != null && !this.version.isEmpty()) {
+			builder.addParameter("v", this.version);
+		}
+		System.out.println(builder.toString());
 		return builder.toString();
 	}
 

--- a/src/main/java/io/quickchart/util/ChartUtils.java
+++ b/src/main/java/io/quickchart/util/ChartUtils.java
@@ -1,0 +1,16 @@
+package io.quickchart.util;
+
+import com.google.gson.Gson;
+
+import io.quickchart.vo.ChartConfig;
+
+public class ChartUtils {
+    
+    public static String getJSON(Object obj) {
+        return new Gson().toJson(obj);
+    }
+
+    public static String getChartConfigJSON(ChartConfig config) {
+        return new Gson().toJson(config);
+    }
+}

--- a/src/main/java/io/quickchart/vo/ChartConfig.java
+++ b/src/main/java/io/quickchart/vo/ChartConfig.java
@@ -1,0 +1,19 @@
+package io.quickchart.vo;
+
+
+public class ChartConfig {
+    private String type;
+    private ChartData data;
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+    public ChartData getData() {
+        return data;
+    }
+    public void setData(ChartData data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/io/quickchart/vo/ChartData.java
+++ b/src/main/java/io/quickchart/vo/ChartData.java
@@ -1,0 +1,20 @@
+package io.quickchart.vo;
+
+import java.util.List;
+
+public class ChartData {
+    private List<String> labels;
+    private List<Dataset> datasets;
+    public List<String> getLabels() {
+        return labels;
+    }
+    public void setLabels(List<String> labels) {
+        this.labels = labels;
+    }
+    public List<Dataset> getDatasets() {
+        return datasets;
+    }
+    public void setDatasets(List<Dataset> datasets) {
+        this.datasets = datasets;
+    }
+}

--- a/src/main/java/io/quickchart/vo/Dataset.java
+++ b/src/main/java/io/quickchart/vo/Dataset.java
@@ -1,0 +1,20 @@
+package io.quickchart.vo;
+
+import java.util.List;
+
+public class Dataset {
+    private String label;
+    private List<String> data;
+    public String getLabel() {
+        return label;
+    }
+    public void setLabel(String label) {
+        this.label = label;
+    }
+    public List<String> getData() {
+        return data;
+    }
+    public void setData(List<String> data) {
+        this.data = data;
+    }
+}

--- a/src/test/java/io/quickchart/core/QuickChartTest.java
+++ b/src/test/java/io/quickchart/core/QuickChartTest.java
@@ -1,6 +1,11 @@
 package io.quickchart.core;
 
+import java.util.List;
+
 import io.quickchart.QuickChart;
+import io.quickchart.vo.ChartConfig;
+import io.quickchart.vo.ChartData;
+import io.quickchart.vo.Dataset;
 import junit.framework.TestCase;
 
 public class QuickChartTest extends TestCase {
@@ -101,5 +106,28 @@ public class QuickChartTest extends TestCase {
 		assertTrue(url.indexOf("50%2C+60%2C+") > -1);
 		assertTrue(url.indexOf("v=2.9.4") > -1);
 		assertTrue(url.indexOf("bkg=") < 0);
+	}
+
+	public void testgetUrlV2(){
+		QuickChart chart = new QuickChart();
+		chart.setVersion("2.9.4");
+		chart.setWidth(500);
+		chart.setHeight(300);
+		ChartConfig config = new ChartConfig();
+		config.setType("bar");
+		ChartData data = new ChartData();
+		data.setLabels(List.of("Q1", "Q2", "Q3", "Q4"));
+		Dataset dataset = new Dataset();
+		dataset.setLabel("Users");
+		dataset.setData(List.of("50", "60", "70", "180"));
+		Dataset dataset2 = new Dataset();
+		dataset2.setLabel("Revenue");
+		dataset2.setData(List.of("100", "200", "300", "400"));
+		data.setDatasets(List.of(dataset, dataset2));
+		config.setData(data);
+		chart.setChartConfig(config);
+		String url = chart.getUrlV2();
+		System.out.println(url);
+		assertTrue(url.indexOf("https://quickchart.io/chart") == 0);
 	}
 }


### PR DESCRIPTION
If user want to provide your Chart.js config in a neat manner instead of doing all the string formatting, you can use `getUrlV2()`

Example:
```java
// Instanciate ChartConfig object
ChartConfig config = new ChartConfig();

// Set the char type. e.g bar, line etc
config.setType("bar");
//Instantiate ChartData
ChartData data = new ChartData();
// Set the labels and chart Data
data.setLabels(List.of("Q1", "Q2", "Q3", "Q4"));  //labels

//Dataset 1
Dataset dataset = new Dataset();
dataset.setLabel("Users");
dataset.setData(List.of("50", "60", "70", "180"));

//Dataset 2
Dataset dataset2 = new Dataset();
dataset2.setLabel("Revenue");
dataset2.setData(List.of("100", "200", "300", "400"));

//Set the required Data
data.setDatasets(List.of(dataset, dataset2));
config.setData(data);
chart.setChartConfig(config);

//get the URL
chart.getUrlV2()

```